### PR TITLE
Fix authorized log typo

### DIFF
--- a/Sovereign.Discord/Discord/Commands/LinkCommands.cs
+++ b/Sovereign.Discord/Discord/Commands/LinkCommands.cs
@@ -97,7 +97,7 @@ public class LinkCommands : ExtendedInteractionModuleBase
                 if (linkResponse.Status == ResponseStatus.Success)
                 {
                     await context.RespondAsync($"Successfully linked your account with the Roblox user {robloxUserId}.");
-                    Logger.Info($"Discord user {discordUserId} succesfully linked with Roblox user {robloxUserId}.");
+                    Logger.Info($"Discord user {discordUserId} successfully linked with Roblox user {robloxUserId}.");
                 }
                 else if (linkResponse.Status == ResponseStatus.Forbidden)
                 {

--- a/Sovereign.Discord/Discord/Commands/LinkCommands.cs
+++ b/Sovereign.Discord/Discord/Commands/LinkCommands.cs
@@ -97,7 +97,7 @@ public class LinkCommands : ExtendedInteractionModuleBase
                 if (linkResponse.Status == ResponseStatus.Success)
                 {
                     await context.RespondAsync($"Successfully linked your account with the Roblox user {robloxUserId}.");
-                    Logger.Info($"Discord user {discordUserId} attempted to link with Roblox user {robloxUserId} but was not authorized.");
+                    Logger.Info($"Discord user {discordUserId} succesfully linked with Roblox user {robloxUserId}.");
                 }
                 else if (linkResponse.Status == ResponseStatus.Forbidden)
                 {


### PR DESCRIPTION
When a Discord user successfully linked their Roblox account, it would still log it as not authorized.